### PR TITLE
Verify TLS connection

### DIFF
--- a/lib/tackle.ex
+++ b/lib/tackle.ex
@@ -33,7 +33,7 @@ defmodule Tackle do
   @doc false
   def execute(rabbitmq_url, fun) when is_binary(rabbitmq_url) and is_function(fun, 1) do
     Logger.debug("Connecting to '#{Tackle.DebugHelper.safe_uri(rabbitmq_url)}'")
-    {:ok, connection} = AMQP.Connection.open(rabbitmq_url)
+    {:ok, connection} = Tackle.Connection.open(rabbitmq_url)
     {:ok, channel} = AMQP.Channel.open(connection)
 
     try do

--- a/lib/tackle/connection.ex
+++ b/lib/tackle/connection.ex
@@ -115,5 +115,22 @@ defmodule Tackle.Connection do
     {:error, :no_process}
   end
 
-  def open(url), do: AMQP.Connection.open(url)
+  @spec open(String.t()) :: {:ok, AMQP.Connection.t()} | {:error, atom()} | {:error, any()}
+  def open(url) do
+    AMQP.Connection.open(url)
+  end
+
+  # Saving OS certs during compile time. Fetching them during runtime results in
+  # a {:EXIT, #Port<0.44>, :normal} message received by the Executor GenServer.
+  # @certs :public_key.cacerts_get()
+  #
+  # def open(url) do
+  #   AMQP.Connection.open(url,
+  #     ssl_options: [
+  #       verify: :verify_peer,
+  #       cacerts: @certs,
+  #       customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
+  #     ]
+  #   )
+  # end
 end

--- a/lib/tackle/connection.ex
+++ b/lib/tackle/connection.ex
@@ -116,8 +116,6 @@ defmodule Tackle.Connection do
   end
 
   @spec open(String.t()) :: {:ok, AMQP.Connection.t()} | {:error, atom()} | {:error, any()}
-  # Saving OS certs during compile time. Fetching them during runtime results in
-  # a {:EXIT, #Port<0.44>, :normal} message received by the Executor GenServer.
   def open("amqps" <> _ = url) do
     certs = :public_key.cacerts_get()
 

--- a/lib/tackle/connection.ex
+++ b/lib/tackle/connection.ex
@@ -132,6 +132,12 @@ defmodule Tackle.Connection do
   end
 
   def open(url) do
+    if Mix.env() == :prod do
+      Logger.error(
+        "You are starting tackle without a secure amqps:// connection in production. This is a serious vulnerability of your system. Please specify a secure amqps:// URL."
+      )
+    end
+
     AMQP.Connection.open(url)
   end
 end

--- a/lib/tackle/connection.ex
+++ b/lib/tackle/connection.ex
@@ -116,21 +116,22 @@ defmodule Tackle.Connection do
   end
 
   @spec open(String.t()) :: {:ok, AMQP.Connection.t()} | {:error, atom()} | {:error, any()}
+  # Saving OS certs during compile time. Fetching them during runtime results in
+  # a {:EXIT, #Port<0.44>, :normal} message received by the Executor GenServer.
+  def open("amqps" <> _ = url) do
+    certs = :public_key.cacerts_get()
+
+    AMQP.Connection.open(url,
+      name: "secure",
+      ssl_options: [
+        verify: :verify_peer,
+        cacerts: certs,
+        customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
+      ]
+    )
+  end
+
   def open(url) do
     AMQP.Connection.open(url)
   end
-
-  # Saving OS certs during compile time. Fetching them during runtime results in
-  # a {:EXIT, #Port<0.44>, :normal} message received by the Executor GenServer.
-  # @certs :public_key.cacerts_get()
-  #
-  # def open(url) do
-  #   AMQP.Connection.open(url,
-  #     ssl_options: [
-  #       verify: :verify_peer,
-  #       cacerts: @certs,
-  #       customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
-  #     ]
-  #   )
-  # end
 end

--- a/lib/tackle/consumer/executor.ex
+++ b/lib/tackle/consumer/executor.ex
@@ -98,6 +98,11 @@ defmodule Tackle.Consumer.Executor do
     {:stop, {:connection_lost, reason}, state}
   end
 
+  # This message is received because of fetching OS certificates during connection opening in Tackle.Connection.open/1
+  def handle_info({:EXIT, _port, :normal}, state) do
+    {:noreply, state}
+  end
+
   def delivery_handler(consume_callback, error_callback) do
     Process.flag(:trap_exit, true)
 

--- a/lib/tackle/consumer/executor.ex
+++ b/lib/tackle/consumer/executor.ex
@@ -90,9 +90,7 @@ defmodule Tackle.Consumer.Executor do
         } = state
       ) do
     Logger.warn(
-      "Connection process went down (#{inspect(reason)}). Stopping Consumer for queue #{
-        topology.queue
-      }"
+      "Connection process went down (#{inspect(reason)}). Stopping Consumer for queue #{topology.queue}"
     )
 
     {:stop, {:connection_lost, reason}, state}

--- a/lib/tackle/consumer/executor.ex
+++ b/lib/tackle/consumer/executor.ex
@@ -97,6 +97,8 @@ defmodule Tackle.Consumer.Executor do
   end
 
   # This message is received because of fetching OS certificates during connection opening in Tackle.Connection.open/1
+  # It seems to only happen on darwin systems due to the way the certificates are accessed, see here:
+  # https://github.com/erlang/otp/blob/0f4345094b9a57c4166c695b7acbb6087df7e444/lib/public_key/src/pubkey_os_cacerts.erl#L133
   def handle_info({:EXIT, _port, :normal}, state) do
     {:noreply, state}
   end


### PR DESCRIPTION
# Current problems

- [ ] SSL/TLS in Erlang is not safe with default config
- [x] CI breaks with `beam.smp: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory`
- [ ] With the proposed solution in [200a90e](200a90e802ad43174f4ae29b68685a5b913c30e5) there is still the warning `[warning] Connection (#PID<0.3564.1>): Certificate chain verification is not enabled for this TLS connection. Please see https://rabbitmq.com/ssl.html for more information.` omitted. Probably it is caused during `Tackle.Consumer.Executor.setup!/1`. Maybe the cause of this is somewhere in the amqp library.
- [x] [AMQP Client is outdated.](https://github.com/STUDITEMPS/ex-tackle/pull/28)

# TODOs
- [ ] Write test to show insecure behaviour, maybe this [test suite](https://hexdocs.pm/x509/X509.Test.Suite.html) can help
- [ ] RabbitMQ server allows only secure connections (close ports in [CloudAMQP Console and Firewall settings](https://www.cloudamqp.com/docs/cloudamqp-firewall.html))
- [ ] Make it configurable: allow to pass in the SSL options from the application using ex-tackle
- [ ] Fetch certificates during runtime instead of compile like it is currently implemented (it produces a message sent to a GenServer which is currently not handled)
