### PR TITLE
allows overriding child_spec of consumers

### DIFF
--- a/lib/tackle/consumer.ex
+++ b/lib/tackle/consumer.ex
@@ -37,6 +37,8 @@ defmodule Tackle.Consumer do
 
         Supervisor.child_spec(default, [])
       end
+
+      defoverridable(child_spec: 1)
     end
   end
 


### PR DESCRIPTION
GenServers allow overriding child_spec/1.
In the same fashion modules that use Tackle.Consumer should be allowed to override definition of child_spec/1.

This is especially useful when you want to provide some configuration *at runtime* - something that can't be achieved by passings opts to `__using__` macro.